### PR TITLE
Bf/cli exports cc bug

### DIFF
--- a/cli/actions/Export.ts
+++ b/cli/actions/Export.ts
@@ -268,7 +268,12 @@ export class Export {
           replace: '<$1=$2>',
         },
         { regex: /replaced_semicolon_5498615_2/g, replace: ';' },
-        { regex: /([^?]):(.+);$/gm, replace: '$1?:$2;' },
+
+        { regex: /([^!])![ ]*:(.+);$/gm, replace: '$1:$2;' },
+
+        // { regex: /([^?]):(.+);$/gm, replace: '$1?:$2;' },
+        // { regex: /([^!?])!\?:(.+);$/gm, replace: '$1?:$2;' }, //remove !?:
+
         { regex: /([^\r\n:]+) ;$/gm, replace: '$1;' },
         { regex: / \?;$/gm, replace: '?;' },
       );

--- a/cli/actions/Export.ts
+++ b/cli/actions/Export.ts
@@ -422,7 +422,7 @@ export class Export {
     replaces = [],
     opts = { replaceNews: false },
   ) {
-    const libraryRegexStr = `import[^{;]*{([^{;]+)}[^{;]+${library}.+;`;
+    const libraryRegexStr = `import[^{;]*{([^{;]+)}[^{;]+${library}.+`;
     //console.log('libraryRegexStr', libraryRegexStr);
     const libraryRegex = new RegExp(libraryRegexStr, 'gm');
     // loop through all files in the eicrud_exports directory

--- a/test/src/services/star-fruit/star-fruit.entity.ts
+++ b/test/src/services/star-fruit/star-fruit.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-import { IsString, IsOptional } from 'class-validator';
+import { IsString, IsOptional } from 'class-validator'; //this is a test, no semi-colon here
 import { CrudEntity } from '@eicrud/core/crud';
 
 @Entity()


### PR DESCRIPTION
fix(cli): decorators not removed if import not ending with semi-colon
fix(cli): `export dtos -cc` would unintendedly make the new interfaces' fields optionals